### PR TITLE
Fix/Update PaperClip to 5.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem 'devise'
 
 # For Blog & Comment use
 gem 'ckeditor'
-gem 'paperclip'
+gem 'paperclip', '5.2.0'
 
 # Local Time for easy breakdown of time and date
 gem 'local_time'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     orm_adapter (0.5.0)
-    paperclip (5.1.0)
+    paperclip (5.2.0)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
       cocaine (~> 0.5.5)
@@ -249,7 +249,7 @@ DEPENDENCIES
   less-rails
   listen (~> 3.0.5)
   local_time
-  paperclip
+  paperclip (= 5.2.0)
   pg (~> 0.18)
   pry
   puma (~> 3.0)


### PR DESCRIPTION
Updating Paperclip Gem to 5.2.0 for security flaw

Referenced here: https://github.com/thoughtbot/paperclip/issues/2530